### PR TITLE
Fix issue with footnotes plugin

### DIFF
--- a/site/plugins/footnotes/index.php
+++ b/site/plugins/footnotes/index.php
@@ -7,12 +7,11 @@
 			$new_blocks = [];
 			foreach ($this as $block) {
 				$block = $block->toArray();
-
 				// Image blocks don't have text.
-				if (!isset($block["content"]["text"])) continue;
-
-				$block["content"]["text"] =
-					Footnotes::collect($block["content"]["text"]);
+				if (isset($block["content"]["text"])) {
+					$block["content"]["text"] =
+						Footnotes::collect($block["content"]["text"]);
+				}
 				array_push($new_blocks, new Kirby\Cms\Block($block));
 			}
 			return new Kirby\Cms\Blocks($new_blocks);


### PR DESCRIPTION
Blocks that don't have text would not be displayed.