### PR TITLE
Fix issues with date

### DIFF
--- a/site/controllers/articles.php
+++ b/site/controllers/articles.php
@@ -26,7 +26,7 @@ return function () {
 	}
 
 	return [
-		"articles" => $articles,
+		"articles" => $articles->sort("date", "desc"),
 		"authors" => $authors,
 		"keywords" => $keywords
 	];

--- a/site/controllers/reviews.php
+++ b/site/controllers/reviews.php
@@ -6,8 +6,8 @@ return function ($site) {
 	$authors = [];
 	$keywords = [];
 	$reviews = $site->index()
-				 ->filterBy('template', 'review')->listed()
-				 ->sortBy('date', 'desc');
+		->filterBy('template', 'review')->listed()
+		->sortBy('date', 'desc');
 
 	foreach ($reviews as $review) {
 		foreach ($review->keywords()->split() as $kw) {

--- a/site/models/article.php
+++ b/site/models/article.php
@@ -4,6 +4,17 @@ use Kirby\Cms\Page;
 
 class ArticlePage extends Page
 {
+
+	public function date()
+	{
+		return $this->parent()->date();
+	}
+
+	public function fmt_date()
+	{
+		return $this->parent()->fmt_date();
+	}
+
 	public function title_and_subtitle()
 	{
 		$title = parent::title()->smartypants();

--- a/site/models/interview.php
+++ b/site/models/interview.php
@@ -4,6 +4,14 @@ use Kirby\Cms\Page;
 
 class InterviewPage extends Page
 {
+
+	public function fmt_date()
+	{
+		$formatted_date = parent::date()->toDate("MMMM Y");
+		if (!$formatted_date) return $this->parent()->fmt_date();
+		return ucfirst($formatted_date);
+	}
+
 	public function title_and_subtitle()
 	{
 		$title = parent::title()->smartypants();

--- a/site/models/issue.php
+++ b/site/models/issue.php
@@ -4,12 +4,12 @@ use Kirby\Cms\Page;
 
 class IssuePage extends Page
 {
-	public function date()
+	public function fmt_date()
 	{
 		$formatted_date = parent::date()->toDate("MMMM Y");
 		return ucfirst($formatted_date);
 	}
-	
+
 	// Can't format title here because the panel it causes issues
 	// in the Panel. For instance, it displays the Unicode code for
 	// the apostrophe instead of the apostrophe itself.

--- a/site/models/review.php
+++ b/site/models/review.php
@@ -4,6 +4,14 @@ use Kirby\Cms\Page;
 
 class ReviewPage extends Page
 {
+
+	public function fmt_date()
+	{
+		$formatted_date = parent::date()->toDate("MMMM Y");
+		if (!$formatted_date) return $this->parent()->fmt_date();
+		return ucfirst($formatted_date);
+	}
+
 	public function title_and_subtitle()
 	{
 		$title = parent::title()->smartypants();

--- a/site/snippets/article/citation.php
+++ b/site/snippets/article/citation.php
@@ -13,5 +13,5 @@ foreach ($authors as $i => $author) {
 	<?= $citation_authors ?>.
 	<?= $page->title_and_subtitle() ?>,
 	Post-Scriptum <?= $page->parent()->num() ?>.
-	(<?= $page->parent()->date() ?>).
+	(<?= $page->fmt_date() ?>).
 </p>


### PR DESCRIPTION
Add a fmt_date field to use in citation. Articles that don't have a date inherit it from their parent issue.